### PR TITLE
Replace BlobStorage ConnectionString with Managed Identity

### DIFF
--- a/src/Equinor.ProCoSys.BlobStorage/AzureBlobService.cs
+++ b/src/Equinor.ProCoSys.BlobStorage/AzureBlobService.cs
@@ -30,15 +30,15 @@ namespace Equinor.ProCoSys.BlobStorage
         public AzureBlobService(IOptionsMonitor<BlobStorageOptions> options, TokenCredential credential)
         {
 
-            if (string.IsNullOrEmpty(options.CurrentValue.BlobStorageAccountName))
+            if (string.IsNullOrEmpty(options.CurrentValue.AccountName))
             {
-                throw new ArgumentNullException(nameof(options.CurrentValue.BlobStorageAccountName));
+                throw new ArgumentNullException(nameof(options.CurrentValue.AccountName));
             }
 
-            AccountName = options.CurrentValue.BlobStorageAccountName;
+            AccountName = options.CurrentValue.AccountName;
             Credential = credential;
 
-            AccountDomain = options.CurrentValue.BlobStorageAccountName + _blobStorageUrlSuffix;
+            AccountDomain = options.CurrentValue.AccountName + _blobStorageUrlSuffix;
             AccountUrl = "https://" + AccountDomain;
         }
 

--- a/src/Equinor.ProCoSys.BlobStorage/AzureBlobService.cs
+++ b/src/Equinor.ProCoSys.BlobStorage/AzureBlobService.cs
@@ -21,9 +21,9 @@ namespace Equinor.ProCoSys.BlobStorage
             public const string CONTAINER = "c";
         }
 
-        public string Endpoint { get; private set; }
+        public string AccountUrl { get; private set; }
         public string AccountName { get; private set; }
-        public string HostEndpoint { get; private set; }
+        public string HostUrl { get; private set; }
         public TokenCredential Credential { get; private set; }
 
         public AzureBlobService(IOptionsMonitor<BlobStorageOptions> options, TokenCredential credential)
@@ -38,15 +38,18 @@ namespace Equinor.ProCoSys.BlobStorage
                 throw new ArgumentNullException(nameof(options.CurrentValue.BlobStorageAccountName));
             }
 
-            Endpoint = options.CurrentValue.BlobStorageAccountUrl;
             AccountName = options.CurrentValue.BlobStorageAccountName;
-            HostEndpoint = Regex.Match(Endpoint, @"https://(.+?)(;|\z)", RegexOptions.Singleline).Groups[1].Value;
             Credential = credential;
+
+            // Example: https://mystorage.blob.core.windows.net
+            AccountUrl = "https://" + options.CurrentValue.BlobStorageAccountUrl;
+            // Example: mystorage.blob.core.windows.net
+            HostUrl = options.CurrentValue.BlobStorageAccountUrl;
         }
 
         private BlobClient GetBlobClient(string container, string blobPath)
         {
-            var blobUri = new Uri($"{Endpoint}/{container}/{blobPath}");
+            var blobUri = new Uri($"{AccountUrl}/{container}/{blobPath}");
             return new BlobClient(blobUri, Credential);
         }
 
@@ -118,7 +121,7 @@ namespace Equinor.ProCoSys.BlobStorage
 
         public async Task<List<string>> ListAsync(string container, CancellationToken cancellationToken = default)
         {
-            var client = new BlobContainerClient(new Uri($"{Endpoint}/{container}"), Credential);
+            var client = new BlobContainerClient(new Uri($"{AccountUrl}/{container}"), Credential);
             var blobNames = new List<string>();
             await foreach (var blob in client.GetBlobsAsync(BlobTraits.None, BlobStates.None, null, cancellationToken))
             {
@@ -133,7 +136,7 @@ namespace Equinor.ProCoSys.BlobStorage
             var fullUri = new UriBuilder
             {
                 Scheme = "https",
-                Host = HostEndpoint,
+                Host = HostUrl,
                 Path = Path.Combine(container, blobPath),
                 Query = sasToken
             };
@@ -146,7 +149,7 @@ namespace Equinor.ProCoSys.BlobStorage
             var fullUri = new UriBuilder
             {
                 Scheme = "https",
-                Host = HostEndpoint,
+                Host = HostUrl,
                 Path = Path.Combine(container, blobPath),
                 Query = sasToken
             };
@@ -159,7 +162,7 @@ namespace Equinor.ProCoSys.BlobStorage
             var fullUri = new UriBuilder
             {
                 Scheme = "https",
-                Host = HostEndpoint,
+                Host = HostUrl,
                 Path = Path.Combine(container, blobPath),
                 Query = sasToken
             };
@@ -172,7 +175,7 @@ namespace Equinor.ProCoSys.BlobStorage
             var fullUri = new UriBuilder
             {
                 Scheme = "https",
-                Host = HostEndpoint,
+                Host = HostUrl,
                 Path = container,
                 Query = $"restype=container&comp=list&{sasToken}"
             };

--- a/src/Equinor.ProCoSys.BlobStorage/AzureBlobService.cs
+++ b/src/Equinor.ProCoSys.BlobStorage/AzureBlobService.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
@@ -21,17 +20,15 @@ namespace Equinor.ProCoSys.BlobStorage
             public const string CONTAINER = "c";
         }
 
-        public string AccountUrl { get; private set; }
+        private readonly string _blobStorageUrlSuffix = ".blob.core.windows.net";
+
+        public string AccountDomain { get; private set; }
         public string AccountName { get; private set; }
-        public string HostUrl { get; private set; }
+        public string AccountUrl { get; private set; }
         public TokenCredential Credential { get; private set; }
 
         public AzureBlobService(IOptionsMonitor<BlobStorageOptions> options, TokenCredential credential)
         {
-            if (string.IsNullOrEmpty(options.CurrentValue.BlobStorageAccountUrl))
-            {
-                throw new ArgumentNullException(nameof(options.CurrentValue.BlobStorageAccountUrl));
-            }
 
             if (string.IsNullOrEmpty(options.CurrentValue.BlobStorageAccountName))
             {
@@ -41,10 +38,8 @@ namespace Equinor.ProCoSys.BlobStorage
             AccountName = options.CurrentValue.BlobStorageAccountName;
             Credential = credential;
 
-            // Example: https://mystorage.blob.core.windows.net
-            AccountUrl = "https://" + options.CurrentValue.BlobStorageAccountUrl;
-            // Example: mystorage.blob.core.windows.net
-            HostUrl = options.CurrentValue.BlobStorageAccountUrl;
+            AccountDomain = options.CurrentValue.BlobStorageAccountName + _blobStorageUrlSuffix;
+            AccountUrl = "https://" + AccountDomain;
         }
 
         private BlobClient GetBlobClient(string container, string blobPath)
@@ -136,7 +131,7 @@ namespace Equinor.ProCoSys.BlobStorage
             var fullUri = new UriBuilder
             {
                 Scheme = "https",
-                Host = HostUrl,
+                Host = AccountDomain,
                 Path = Path.Combine(container, blobPath),
                 Query = sasToken
             };
@@ -149,7 +144,7 @@ namespace Equinor.ProCoSys.BlobStorage
             var fullUri = new UriBuilder
             {
                 Scheme = "https",
-                Host = HostUrl,
+                Host = AccountDomain,
                 Path = Path.Combine(container, blobPath),
                 Query = sasToken
             };
@@ -162,7 +157,7 @@ namespace Equinor.ProCoSys.BlobStorage
             var fullUri = new UriBuilder
             {
                 Scheme = "https",
-                Host = HostUrl,
+                Host = AccountDomain,
                 Path = Path.Combine(container, blobPath),
                 Query = sasToken
             };
@@ -175,7 +170,7 @@ namespace Equinor.ProCoSys.BlobStorage
             var fullUri = new UriBuilder
             {
                 Scheme = "https",
-                Host = HostUrl,
+                Host = AccountDomain,
                 Path = container,
                 Query = $"restype=container&comp=list&{sasToken}"
             };

--- a/src/Equinor.ProCoSys.BlobStorage/AzureBlobService.cs
+++ b/src/Equinor.ProCoSys.BlobStorage/AzureBlobService.cs
@@ -48,7 +48,7 @@ namespace Equinor.ProCoSys.BlobStorage
             Endpoint = options.CurrentValue.BlobStorageAccountUrl;
             AccountName = options.CurrentValue.BlobStorageAccountName;
             AccountKey = options.CurrentValue.BlobStorageAccountKey;
-            HostEndpoint = Regex.Match(AccountName, @"https//(.+?)(;|\z)", RegexOptions.Singleline).Groups[1].Value;
+            HostEndpoint = Regex.Match(Endpoint, @"https://(.+?)(;|\z)", RegexOptions.Singleline).Groups[1].Value;
             Credential = new DefaultAzureCredential();
         }
 

--- a/src/Equinor.ProCoSys.BlobStorage/BlobStorageOptions.cs
+++ b/src/Equinor.ProCoSys.BlobStorage/BlobStorageOptions.cs
@@ -2,7 +2,7 @@
 {
     public class BlobStorageOptions
     {
-        public string BlobStorageAccountName { get; set; }
+        public string AccountName { get; set; }
         public int MaxSizeMb { get; set; }
         public string BlobContainer { get; set; }
         public int BlobClockSkewMinutes { get; set; }

--- a/src/Equinor.ProCoSys.BlobStorage/BlobStorageOptions.cs
+++ b/src/Equinor.ProCoSys.BlobStorage/BlobStorageOptions.cs
@@ -2,6 +2,7 @@
 {
     public class BlobStorageOptions
     {
+        // Example Url: mystorage.blob.core.windows.net
         public string BlobStorageAccountUrl { get; set; }
         public string BlobStorageAccountName { get; set; }
         public int MaxSizeMb { get; set; }

--- a/src/Equinor.ProCoSys.BlobStorage/BlobStorageOptions.cs
+++ b/src/Equinor.ProCoSys.BlobStorage/BlobStorageOptions.cs
@@ -4,7 +4,6 @@
     {
         public string BlobStorageAccountUrl { get; set; }
         public string BlobStorageAccountName { get; set; }
-        public string BlobStorageAccountKey { get; set; }
         public int MaxSizeMb { get; set; }
         public string BlobContainer { get; set; }
         public int BlobClockSkewMinutes { get; set; }

--- a/src/Equinor.ProCoSys.BlobStorage/BlobStorageOptions.cs
+++ b/src/Equinor.ProCoSys.BlobStorage/BlobStorageOptions.cs
@@ -2,7 +2,9 @@
 {
     public class BlobStorageOptions
     {
-        public string ConnectionString { get; set; }
+        public string BlobStorageAccountUrl { get; set; }
+        public string BlobStorageAccountName { get; set; }
+        public string BlobStorageAccountKey { get; set; }
         public int MaxSizeMb { get; set; }
         public string BlobContainer { get; set; }
         public int BlobClockSkewMinutes { get; set; }

--- a/src/Equinor.ProCoSys.BlobStorage/BlobStorageOptions.cs
+++ b/src/Equinor.ProCoSys.BlobStorage/BlobStorageOptions.cs
@@ -2,8 +2,6 @@
 {
     public class BlobStorageOptions
     {
-        // Example Url: mystorage.blob.core.windows.net
-        public string BlobStorageAccountUrl { get; set; }
         public string BlobStorageAccountName { get; set; }
         public int MaxSizeMb { get; set; }
         public string BlobContainer { get; set; }

--- a/src/Equinor.ProCoSys.BlobStorage/Equinor.ProCoSys.BlobStorage.csproj
+++ b/src/Equinor.ProCoSys.BlobStorage/Equinor.ProCoSys.BlobStorage.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<VersionPrefix>2.0.5</VersionPrefix>
+		<VersionPrefix>2.1.0</VersionPrefix>
 		<TargetFramework>net8.0</TargetFramework>
 		<Company>Equinor</Company>
 		<Description>Library for interact with Azure Storage in ProCoSys</Description>
@@ -10,6 +10,7 @@
     </PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Azure.Identity" Version="1.12.0" />
 		<PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
 		<PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
 	</ItemGroup>

--- a/src/Equinor.ProCoSys.BlobStorage/IAzureBlobService.cs
+++ b/src/Equinor.ProCoSys.BlobStorage/IAzureBlobService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Azure.Storage.Blobs.Models;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -15,9 +16,9 @@ namespace Equinor.ProCoSys.BlobStorage
         Task<bool> DeleteAsync(string container, string blobPath, CancellationToken cancellationToken = default);
         Task<List<string>> ListAsync(string container, CancellationToken cancellationToken = default);
 
-        Uri GetDownloadSasUri(string container, string blobPath, DateTimeOffset startsOn, DateTimeOffset expiresOn, string startIPAddress = null, string endIPAddress = null);
-        Uri GetUploadSasUri(string container, string blobPath, DateTimeOffset startsOn, DateTimeOffset expiresOn);
-        Uri GetDeleteSasUri(string container, string blobPath, DateTimeOffset startsOn, DateTimeOffset expiresOn);
-        Uri GetListSasUri(string container, DateTimeOffset startsOn, DateTimeOffset expiresOn);
+        Uri GetDownloadSasUri(string container, string blobPath, DateTimeOffset startsOn, DateTimeOffset expiresOn, UserDelegationKey userDelegationKey, string startIPAddress = null, string endIPAddress = null);
+        Uri GetUploadSasUri(string container, string blobPath, DateTimeOffset startsOn, DateTimeOffset expiresOn, UserDelegationKey userDelegationKey);
+        Uri GetDeleteSasUri(string container, string blobPath, DateTimeOffset startsOn, DateTimeOffset expiresOn, UserDelegationKey userDelegationKey);
+        Uri GetListSasUri(string container, DateTimeOffset startsOn, DateTimeOffset expiresOn, UserDelegationKey userDelegationKey);
     }
 }

--- a/src/tests/Equinor.ProCoSys.BlobStorage.Tests/AzureBlobServiceTests.cs
+++ b/src/tests/Equinor.ProCoSys.BlobStorage.Tests/AzureBlobServiceTests.cs
@@ -15,10 +15,10 @@ namespace Equinor.ProCoSys.BlobStorage.Tests
             var optionsMock = Substitute.For<IOptionsMonitor<BlobStorageOptions>>();
             var tokenMock = Substitute.For<TokenCredential>();
             var accountName = "pcs";
-            var accountUrl = $"{accountName}.blob.core.windows.net";
+            var accountDomain = $"{accountName}.blob.core.windows.net";
+            var accountUrl = $"https://{accountName}.blob.core.windows.net";
             var options = new BlobStorageOptions
             {
-                BlobStorageAccountUrl = accountUrl,
                 BlobStorageAccountName = accountName,
             };
             optionsMock.CurrentValue.Returns(options);
@@ -27,9 +27,9 @@ namespace Equinor.ProCoSys.BlobStorage.Tests
             var dut = new AzureBlobService(optionsMock, tokenMock);
 
             // Assert
-            Assert.AreEqual(options.BlobStorageAccountUrl, dut.HostUrl);
-            Assert.AreEqual($"https://{accountUrl}", dut.AccountUrl);
-            Assert.AreEqual(accountName, dut.AccountName);
+            Assert.AreEqual(options.BlobStorageAccountName, dut.AccountName);
+            Assert.AreEqual(accountDomain, dut.AccountDomain);
+            Assert.AreEqual(accountUrl, dut.AccountUrl);
         }
     }
 }

--- a/src/tests/Equinor.ProCoSys.BlobStorage.Tests/AzureBlobServiceTests.cs
+++ b/src/tests/Equinor.ProCoSys.BlobStorage.Tests/AzureBlobServiceTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Options;
+﻿using Azure.Core;
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 
@@ -12,25 +13,23 @@ namespace Equinor.ProCoSys.BlobStorage.Tests
         {
             // Arrange
             var optionsMock = Substitute.For<IOptionsMonitor<BlobStorageOptions>>();
+            var tokenMock = Substitute.For<TokenCredential>();
             var accountName = "pcs";
-            var accountKey = "pw";
             var endpoint = $"https://{accountName}.blob.core.windows.net";
             var options = new BlobStorageOptions
             {
                 BlobStorageAccountUrl = endpoint,
                 BlobStorageAccountName = accountName,
-                BlobStorageAccountKey = accountKey,
             };
             optionsMock.CurrentValue.Returns(options);
             
             // Act
-            var dut = new AzureBlobService(optionsMock);
+            var dut = new AzureBlobService(optionsMock, tokenMock);
 
             // Assert
             Assert.AreEqual(options.BlobStorageAccountUrl, dut.Endpoint);
             Assert.AreEqual($"{accountName}.blob.core.windows.net", dut.HostEndpoint);
             Assert.AreEqual(accountName, dut.AccountName);
-            Assert.AreEqual(accountKey, dut.AccountKey);
         }
     }
 }

--- a/src/tests/Equinor.ProCoSys.BlobStorage.Tests/AzureBlobServiceTests.cs
+++ b/src/tests/Equinor.ProCoSys.BlobStorage.Tests/AzureBlobServiceTests.cs
@@ -19,7 +19,7 @@ namespace Equinor.ProCoSys.BlobStorage.Tests
             var accountUrl = $"https://{accountName}.blob.core.windows.net";
             var options = new BlobStorageOptions
             {
-                BlobStorageAccountName = accountName,
+                AccountName = accountName,
             };
             optionsMock.CurrentValue.Returns(options);
             
@@ -27,7 +27,7 @@ namespace Equinor.ProCoSys.BlobStorage.Tests
             var dut = new AzureBlobService(optionsMock, tokenMock);
 
             // Assert
-            Assert.AreEqual(options.BlobStorageAccountName, dut.AccountName);
+            Assert.AreEqual(options.AccountName, dut.AccountName);
             Assert.AreEqual(accountDomain, dut.AccountDomain);
             Assert.AreEqual(accountUrl, dut.AccountUrl);
         }

--- a/src/tests/Equinor.ProCoSys.BlobStorage.Tests/AzureBlobServiceTests.cs
+++ b/src/tests/Equinor.ProCoSys.BlobStorage.Tests/AzureBlobServiceTests.cs
@@ -8,16 +8,18 @@ namespace Equinor.ProCoSys.BlobStorage.Tests
     public class AzureBlobServiceTests
     {
         [TestMethod]
-        public void Constructor_Should_Accept_ConnectionString()
+        public void Constructor_Should_Accept_BlobStorageAccountUrl()
         {
             // Arrange
             var optionsMock = Substitute.For<IOptionsMonitor<BlobStorageOptions>>();
             var accountName = "pcs";
             var accountKey = "pw";
-            var endpoint = "core.windows.net";
+            var endpoint = $"https://{accountName}.blob.core.windows.net";
             var options = new BlobStorageOptions
             {
-                ConnectionString = $"DefaultEndpointsProtocol=https;AccountName={accountName};AccountKey={accountKey};EndpointSuffix={endpoint}"
+                BlobStorageAccountUrl = endpoint,
+                BlobStorageAccountName = accountName,
+                BlobStorageAccountKey = accountKey,
             };
             optionsMock.CurrentValue.Returns(options);
             
@@ -25,10 +27,10 @@ namespace Equinor.ProCoSys.BlobStorage.Tests
             var dut = new AzureBlobService(optionsMock);
 
             // Assert
-            Assert.AreEqual(options.ConnectionString, dut.ConnectionString);
+            Assert.AreEqual(options.BlobStorageAccountUrl, dut.Endpoint);
+            Assert.AreEqual($"{accountName}.blob.core.windows.net", dut.HostEndpoint);
             Assert.AreEqual(accountName, dut.AccountName);
             Assert.AreEqual(accountKey, dut.AccountKey);
-            Assert.AreEqual("blob." + endpoint, dut.Endpoint);
         }
     }
 }

--- a/src/tests/Equinor.ProCoSys.BlobStorage.Tests/AzureBlobServiceTests.cs
+++ b/src/tests/Equinor.ProCoSys.BlobStorage.Tests/AzureBlobServiceTests.cs
@@ -15,10 +15,10 @@ namespace Equinor.ProCoSys.BlobStorage.Tests
             var optionsMock = Substitute.For<IOptionsMonitor<BlobStorageOptions>>();
             var tokenMock = Substitute.For<TokenCredential>();
             var accountName = "pcs";
-            var endpoint = $"https://{accountName}.blob.core.windows.net";
+            var accountUrl = $"{accountName}.blob.core.windows.net";
             var options = new BlobStorageOptions
             {
-                BlobStorageAccountUrl = endpoint,
+                BlobStorageAccountUrl = accountUrl,
                 BlobStorageAccountName = accountName,
             };
             optionsMock.CurrentValue.Returns(options);
@@ -27,8 +27,8 @@ namespace Equinor.ProCoSys.BlobStorage.Tests
             var dut = new AzureBlobService(optionsMock, tokenMock);
 
             // Assert
-            Assert.AreEqual(options.BlobStorageAccountUrl, dut.Endpoint);
-            Assert.AreEqual($"{accountName}.blob.core.windows.net", dut.HostEndpoint);
+            Assert.AreEqual(options.BlobStorageAccountUrl, dut.HostUrl);
+            Assert.AreEqual($"https://{accountUrl}", dut.AccountUrl);
             Assert.AreEqual(accountName, dut.AccountName);
         }
     }


### PR DESCRIPTION
Updated BlobStorage to use Managed Identity instead of a ConnectionString

https://github.com/equinor/cc-toolbox/issues/527