### PR TITLE
792 Build error fix

### DIFF
--- a/src/Equinor.ProCoSys.Auth/Equinor.ProCoSys.Auth.csproj
+++ b/src/Equinor.ProCoSys.Auth/Equinor.ProCoSys.Auth.csproj
@@ -11,10 +11,8 @@
 
 	<ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
-		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
         <PackageReference Include="Microsoft.Identity.Web.TokenAcquisition" Version="2.19.1" />
         <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
 	</ItemGroup>


### PR DESCRIPTION
Equinor.ProCoSys.Auth.csproj: Error NU1903 : Warning As Error: Package 'Microsoft.Extensions.Caching.Memory' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-qj66-m88j-hmgj

Updated Microsoft.Extensions.Caching.Memory to 8.0.1

Removd dependant packages that were making it difficult to update the package. They are implicitly included.

https://github.com/equinor/cc-toolbox/issues/792