### PR TITLE
1608 log formatting fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,7 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# JetBrains Rider
+.idea/
+*.sln.iml

--- a/src/Equinor.ProCoSys.Common/Caches/DistributedCacheManager.cs
+++ b/src/Equinor.ProCoSys.Common/Caches/DistributedCacheManager.cs
@@ -32,7 +32,7 @@ public sealed class DistributedCacheManager(
         if (item != null && !item.Equals(default(T)))
         {
             sw.Stop();
-            logger.LogInformation("Fetching from cache ({Elapsed}ms) '{Key}', Elapsed ", key, sw.ElapsedMilliseconds);
+            logger.LogInformation("Fetching from cache ({Elapsed}ms) '{Key}', Elapsed ", sw.ElapsedMilliseconds, key);
             return item;
         }
 
@@ -40,7 +40,7 @@ public sealed class DistributedCacheManager(
         await AddToCache(item, key, duration, expiration, cancellationToken);
 
         sw.Stop();
-        logger.LogInformation("Added {Key} to cache ({Elapsed}ms)", key, sw.ElapsedMilliseconds);
+        logger.LogInformation("Added {Key} to cache ({Elapsed}ms)", sw.ElapsedMilliseconds, key);
         return item;
     }
 

--- a/src/Equinor.ProCoSys.Common/Caches/DistributedCacheManager.cs
+++ b/src/Equinor.ProCoSys.Common/Caches/DistributedCacheManager.cs
@@ -40,7 +40,7 @@ public sealed class DistributedCacheManager(
         await AddToCache(item, key, duration, expiration, cancellationToken);
 
         sw.Stop();
-        logger.LogInformation("Added {Key} to cache ({Elapsed}ms)", sw.ElapsedMilliseconds, key);
+        logger.LogInformation("Added {Key} to cache ({Elapsed}ms)", key, sw.ElapsedMilliseconds);
         return item;
     }
 

--- a/src/Equinor.ProCoSys.Common/Caches/DistributedCacheManager.cs
+++ b/src/Equinor.ProCoSys.Common/Caches/DistributedCacheManager.cs
@@ -32,7 +32,7 @@ public sealed class DistributedCacheManager(
         if (item != null && !item.Equals(default(T)))
         {
             sw.Stop();
-            logger.LogInformation("Fetching from cache ({Elapsed}ms) '{Key}', Elapsed ", sw.ElapsedMilliseconds, key);
+            logger.LogInformation("Fetching {Key} from cache ({Elapsed}ms)", key, sw.ElapsedMilliseconds);
             return item;
         }
 

--- a/src/Equinor.ProCoSys.Common/Equinor.ProCoSys.Common.csproj
+++ b/src/Equinor.ProCoSys.Common/Equinor.ProCoSys.Common.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<VersionPrefix>3.0.0</VersionPrefix>
+		<VersionPrefix>3.0.1</VersionPrefix>
 		<TargetFramework>net8.0</TargetFramework>
 		<Company>Equinor</Company>
 		<Description>Library with common code in ProCoSys</Description>


### PR DESCRIPTION
Inverted log formatting parameters were causing malformed logs

E.g.
> Fetching from cache (USER_PLANT_PERMISSION_DATA_F29A3FFF-4FBD-4B63-A918-231F9DC83112_PCS$GULLFAKS_Ams) '59', Elapsed

https://portal.azure.com#@3aa4a235-b6e2-48d5-9195-7fcf05b459b0/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2F343069e3-ceaa-4256-bdc8-49fa3646c1c4%2FresourceGroups%2Frg-pcs5-completion-prod%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2Fappi-pcs5-completion-prod/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAAyspSkxOLQYAoAfuugYAAAA%253D/timespan/P1D/limit/1000